### PR TITLE
feat: add auth_client fortniteNewSwitchGameClient

### DIFF
--- a/docs/auth/auth_clients.md
+++ b/docs/auth/auth_clients.md
@@ -1,5 +1,5 @@
 # Auth Clients
-Every application (e.g. game, website) that utilises Epic's official services is issued an auth client that is used to identify requests sent to Epic, as well as to set boundaries to what a certain application can access.    
+Every application (e.g. game, website) that utilises Epic's official services is issued an auth client that is used to identify requests sent to Epic, as well as to set boundaries to what a certain application can access.
 
 Each auth client is issued a client ID and a secret.
 You can see the permissions of an auth client by looking at the [permissions folder](https://github.com/MixV2/EpicResearch/tree/master/docs/auth/permissions) and the file with the corresponding client ID.
@@ -13,6 +13,7 @@ You can see the permissions of an auth client by looking at the [permissions fol
 | fortniteCNGameClient | efe3cbb938804c74b20e109d0efc1548 | 6e31bdbae6a44f258474733db74f39ba |
 | fortniteXboxGameClient | cfaa14c4bf8744e3a5ef9a5d6c34558d | Unknown |
 | fortniteValkyrieGameClient | 3e13c5c57f594a578abe516eecb673fe | 530e316c337e409893c55ec44f22cd62 |
+| fortniteNewSwitchGameClient | 98f7e42c2e3a4f86a74eb43fbb41ed39 | 0a2449a2-001a-451e-afec-3e812901c4d7 |
 | KairosPC | 5b685653b9904c1d92495ee8859dcb00 | 7Q2mcmneyuvPmoRYfwM7gfErA6iUjhXr |
 | Kairos iOS | 61d2f70175e84a6bba80a5089e597e1c | FbiZv3wbiKpvVKrAeMxiR6WhxZWVbrvA |
 | Kairos Android | 0716a69cb8b2422fbb2a8b0879501471 | cGthdfG68tyE7M3ZHMu3sXUBwqhibKFp |


### PR DESCRIPTION
Add a Switch Console client. Taken from https://github.com/xMistt/DeviceAuthGenerator/

I don't know how to get the permission scheme so I'm not including it here. Hope that someone adds it to `/docs/auth/permissions` soon.