### PR TITLE
Bold grant deprecated

### DIFF
--- a/docs/auth/grant_types/password.md
+++ b/docs/auth/grant_types/password.md
@@ -1,6 +1,6 @@
 # Authenticating by Password
 This grant type, `password`, can be used to generate an access token with an email address and password.  
-However, this grant type has been deprecated on all public clients.
+**However, this grant type has been deprecated on all public clients.**
 
 ## Method
 - Send a `POST` request to https://account-public-service-prod.ol.epicgames.com/account/api/oauth/token:  

--- a/docs/auth/grant_types/password.md
+++ b/docs/auth/grant_types/password.md
@@ -1,6 +1,7 @@
 # Authenticating by Password
 This grant type, `password`, can be used to generate an access token with an email address and password.  
-**However, this grant type has been deprecated on all public clients.**
+
+### ⚠️ However, this grant type has been deprecated on all public clients.**
 
 ## Method
 - Send a `POST` request to https://account-public-service-prod.ol.epicgames.com/account/api/oauth/token:  

--- a/docs/auth/grant_types/token_to_token.md
+++ b/docs/auth/grant_types/token_to_token.md
@@ -1,6 +1,8 @@
 # Authenticating by Token to Token
 This grant type, `token_to_token`, can be used to generate an access token from an already existing access token.    
 
+### However, this grant type has been deprecated on all public clients.
+
 For example, if you had an access token (e.g. `abc123`), you could generate more access tokens (e.g. `def456` and `ghi789`) without invalidating the first token.
 
 ## Method

--- a/docs/auth/grant_types/token_to_token.md
+++ b/docs/auth/grant_types/token_to_token.md
@@ -1,7 +1,7 @@
 # Authenticating by Token to Token
 This grant type, `token_to_token`, can be used to generate an access token from an already existing access token.    
 
-### However, this grant type has been deprecated on all public clients.
+### ⚠️ However, this grant type has been deprecated on all public clients.
 
 For example, if you had an access token (e.g. `abc123`), you could generate more access tokens (e.g. `def456` and `ghi789`) without invalidating the first token.
 


### PR DESCRIPTION
Add 

### ⚠️ However, this grant type has been deprecated on all public clients.

to password and token_to_token