### PR TITLE
Update password.md

### DIFF
--- a/docs/auth/grant_types/password.md
+++ b/docs/auth/grant_types/password.md
@@ -1,6 +1,6 @@
 # Authenticating by Password
 This grant type, `password`, can be used to generate an access token with an email address and password.  
-However, this grant type has been deprecated on all public clients.
+However, this grant type has been deprecated on all public clients and will be removed fully with the update to Oauth2.1.
 
 ## Method
 - Send a `POST` request to https://account-public-service-prod.ol.epicgames.com/account/api/oauth/token:  


### PR DESCRIPTION
Added OAuth2.1 update (so far). I’m adding more since the update occurs soon. 

The grant type password is a legacy way to exchange a users credentials for an access token across EOS. In 2.1 it will be fully omitted.

The password flow provides no mechanism for things like multifactor authentication or delegated accounts, so it is quite limiting in practice.